### PR TITLE
Fix warnings from Clang's UBSan

### DIFF
--- a/sha2.c
+++ b/sha2.c
@@ -37,21 +37,21 @@
 
 #include "sha2.h"
 
-#define SHFR(x, n)    (x >> n)
-#define ROTR(x, n)   ((x >> n) | (x << ((sizeof (x) << 3) - n)))
-#define ROTL(x, n)   ((x << n) | (x >> ((sizeof (x) << 3) - n)))
+#define SHFR(t, x, n)    (x >> n)
+#define ROTR(t, x, n)   ((x >> n) | ((x & (((t)1 << n) - 1)) << ((sizeof (x) << 3) - n)))
+#define ROTL(t, x, n)   ((x << n) | (x >> ((sizeof (x) << 3) - n)))
 #define CH(x, y, z)  ((x & y) ^ (~x & z))
 #define MAJ(x, y, z) ((x & y) ^ (x & z) ^ (y & z))
 
-#define SHA256_F1(x) (ROTR(x,  2) ^ ROTR(x, 13) ^ ROTR(x, 22))
-#define SHA256_F2(x) (ROTR(x,  6) ^ ROTR(x, 11) ^ ROTR(x, 25))
-#define SHA256_F3(x) (ROTR(x,  7) ^ ROTR(x, 18) ^ SHFR(x,  3))
-#define SHA256_F4(x) (ROTR(x, 17) ^ ROTR(x, 19) ^ SHFR(x, 10))
+#define SHA256_F1(x) (ROTR(uint32, x,  2) ^ ROTR(uint32, x, 13) ^ ROTR(uint32, x, 22))
+#define SHA256_F2(x) (ROTR(uint32, x,  6) ^ ROTR(uint32, x, 11) ^ ROTR(uint32, x, 25))
+#define SHA256_F3(x) (ROTR(uint32, x,  7) ^ ROTR(uint32, x, 18) ^ SHFR(uint32, x,  3))
+#define SHA256_F4(x) (ROTR(uint32, x, 17) ^ ROTR(uint32, x, 19) ^ SHFR(uint32, x, 10))
 
-#define SHA512_F1(x) (ROTR(x, 28) ^ ROTR(x, 34) ^ ROTR(x, 39))
-#define SHA512_F2(x) (ROTR(x, 14) ^ ROTR(x, 18) ^ ROTR(x, 41))
-#define SHA512_F3(x) (ROTR(x,  1) ^ ROTR(x,  8) ^ SHFR(x,  7))
-#define SHA512_F4(x) (ROTR(x, 19) ^ ROTR(x, 61) ^ SHFR(x,  6))
+#define SHA512_F1(x) (ROTR(uint64, x, 28) ^ ROTR(uint64, x, 34) ^ ROTR(uint64, x, 39))
+#define SHA512_F2(x) (ROTR(uint64, x, 14) ^ ROTR(uint64, x, 18) ^ ROTR(uint64, x, 41))
+#define SHA512_F3(x) (ROTR(uint64, x,  1) ^ ROTR(uint64, x,  8) ^ SHFR(uint64, x,  7))
+#define SHA512_F4(x) (ROTR(uint64, x, 19) ^ ROTR(uint64, x, 61) ^ SHFR(uint64, x,  6))
 
 #define UNPACK32(x, str)                      \
 {                                             \


### PR DESCRIPTION
[UndefinedBehaviorSanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html) in Clang issues number of warnings due to integer overflow in some situations.